### PR TITLE
Support `ATTACHMENT` option type & `autocomplete` option parameter

### DIFF
--- a/src/icons.tsx
+++ b/src/icons.tsx
@@ -123,6 +123,17 @@ export const Choice = createIcon({
   ),
 });
 
+export const Attachment = createIcon({
+  displayName: 'Attachment',
+  viewBox: '0 0 24 24',
+  path: (
+    <path
+      fill="currentColor"
+      d="M9 16h6v-6h4l-7-7-7 7h4v6zm-4 2h14v2H5v-2z"
+    />
+  ),
+});
+
 export default {
   String,
   Integer,
@@ -135,6 +146,7 @@ export default {
   SubCommandGroup,
   SubCommand,
   Choice,
+  Attachment,
 } as {
   [key in keyof typeof ApplicationCommandOptionType]: ReturnType<
     typeof createIcon

--- a/src/options/OptionBlock.tsx
+++ b/src/options/OptionBlock.tsx
@@ -148,6 +148,19 @@ function OptionBlock({ type, _key, inSubCommand, setters }: OptionBlockProps) {
             >
               Required
             </Checkbox>
+            {['String', 'Integer', 'Number'].indexOf(type) != -1 && (
+              <Checkbox
+                size="lg"
+                colorScheme="blue"
+                onChange={(e) =>
+                  updateLocalOption({
+                    autocomplete: e.target.checked ? true : undefined,
+                  })
+                }
+              >
+                Autocomplete
+              </Checkbox>
+            )}
             <Button mx="1" mt="4" w="32" colorScheme="blue" onClick={addChoice}>
               Add Choice
             </Button>

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,15 +3,16 @@ import create from 'zustand';
 
 export enum ApplicationCommandOptionType {
   SubCommand = 1,
-  SubCommandGroup,
-  String,
-  Integer,
-  Boolean,
-  User,
-  Channel,
-  Role,
-  Mentionable,
-  Number,
+  SubCommandGroup = 2,
+  String = 3,
+  Integer = 4,
+  Boolean = 5,
+  User = 6,
+  Channel = 7,
+  Role = 8,
+  Mentionable = 9,
+  Number = 10,
+  Attachment = 11,
 }
 
 export interface ApplicationCommandOptionChoice {
@@ -28,6 +29,7 @@ export interface ApplicationCommandOption {
   required?: boolean;
   choices?: ApplicationCommandOptionChoice[];
   options?: ApplicationCommandOption[];
+  autocomplete?: boolean;
 }
 
 export interface ApplicationCommand {


### PR DESCRIPTION
SVG for the attachment type was taken from the "upload a file" option in the client. Autocomplete is only available on types string, integer, and number.